### PR TITLE
Corrected a compile error in CoinMessageHander

### DIFF
--- a/CoinUtils/src/CoinMessageHandler.cpp
+++ b/CoinUtils/src/CoinMessageHandler.cpp
@@ -831,7 +831,7 @@ CoinMessageHandler::operator<< (double doublevalue)
 	  sprintf(messageOut_,g_format_,doublevalue);
 	  if (next != format_+2) {
 	    messageOut_+=strlen(messageOut_);
-	    sprintf(messageOut_,format_+2);
+	    sprintf(messageOut_,"%s",format_+2);
 	  }
 	}
 	messageOut_+=strlen(messageOut_);


### PR DESCRIPTION
I had a compile error while trying to compile this with clang (for alicevision), and I applied the suggestion of clang. It compiled. (note: I haven't run the test suite, as it doesn't appear to compile with cmake).